### PR TITLE
chore: add nightly cleanup for generated pages

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,46 @@
+name: Nightly Cleanup
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Prune expired sites
+        id: prune
+        run: |
+          npm run prune | tee pruned.log
+          cat pruned.log >> $GITHUB_STEP_SUMMARY
+      - name: Commit changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "[CI] prune expired sites"
+            git push
+          fi
+      - name: Build
+        run: |
+          npm run build
+          touch dist/.nojekyll
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint . --ext ts,tsx",
     "test": "vitest",
+    "prune": "node scripts/pruneExpiredSites.js",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/scripts/pruneExpiredSites.js
+++ b/scripts/pruneExpiredSites.js
@@ -1,0 +1,35 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const devLog = (...args) => console.log(...args);
+
+export async function pruneExpiredSites(baseDir = path.join(process.cwd(), 'src', 'generated'), now = Date.now()) {
+  const entries = await fs.readdir(baseDir, { withFileTypes: true }).catch(() => []);
+  const deleted = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const full = path.join(baseDir, entry.name);
+    const stat = await fs.stat(full);
+    if (now - stat.mtimeMs > DAY_MS) {
+      await fs.rm(full, { recursive: true, force: true });
+      deleted.push(entry.name);
+    }
+  }
+  return deleted;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  pruneExpiredSites().then((deleted) => {
+    if (deleted.length === 0) {
+      devLog('No expired sites found');
+    } else {
+      for (const d of deleted) {
+        devLog(`Removed ${d}`);
+      }
+    }
+  }).catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/src/pruneExpiredSites.test.ts
+++ b/src/pruneExpiredSites.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { execSync } from 'child_process';
+import { pruneExpiredSites } from '../scripts/pruneExpiredSites.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('pruneExpiredSites', () => {
+  it('removes directories older than 24h and keeps others', async () => {
+    vi.useFakeTimers();
+    const now = new Date('2024-01-02T00:00:00Z');
+    vi.setSystemTime(now);
+
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'prune-'));
+    execSync('git init', { cwd: tmp });
+
+    const generatedDir = path.join(tmp, 'src', 'generated');
+    await fs.mkdir(generatedDir, { recursive: true });
+
+    const oldDir = path.join(generatedDir, 'old');
+    const freshDir = path.join(generatedDir, 'fresh');
+    await fs.mkdir(oldDir);
+    await fs.mkdir(freshDir);
+
+    const oldTime = new Date(now.getTime() - 2 * DAY_MS);
+    await fs.utimes(oldDir, oldTime, oldTime);
+    await fs.utimes(freshDir, now, now);
+
+    const nojekyllPath = path.join(tmp, '.nojekyll');
+    await fs.writeFile(nojekyllPath, '');
+
+    const deleted = await pruneExpiredSites(generatedDir);
+    expect(deleted).toEqual(['old']);
+
+    const oldExists = await fs.stat(oldDir).then(() => true).catch(() => false);
+    const freshExists = await fs.stat(freshDir).then(() => true).catch(() => false);
+    expect(oldExists).toBe(false);
+    expect(freshExists).toBe(true);
+
+    const nojekyllExists = await fs.stat(nojekyllPath).then(() => true).catch(() => false);
+    expect(nojekyllExists).toBe(true);
+
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- prune generated site folders older than 24h
- schedule nightly GitHub Action to delete old sites and redeploy pages
- log pruned folders and keep `.nojekyll`

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_689482964cfc832e85bcbc66d8b4ac1f